### PR TITLE
fix(ux): update the search focus for emojis, emoticons, and gifs

### DIFF
--- a/lib/components/root/emoticon.dart
+++ b/lib/components/root/emoticon.dart
@@ -9,13 +9,15 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fuzzywuzzy/fuzzywuzzy.dart';
 
 class Emoticon extends HookWidget {
-  const Emoticon({Key? key}) : super(key: key);
+  const Emoticon({super.key});
 
   @override
   Widget build(BuildContext context) {
     final searchFocusNode = useFocusNode();
     final searchTerm = useState("");
     final firstEmoticonFocusNode = useFocusNode();
+
+    FocusScope.of(context).requestFocus(searchFocusNode);
 
     final List<Map<String, String>> filteredEmoticons = useMemoized(
       () {
@@ -70,28 +72,36 @@ class Emoticon extends HookWidget {
       padding: const EdgeInsets.all(8.0),
       child: Column(
         children: [
-          CallbackShortcuts(
-            bindings: {
-              LogicalKeySet(LogicalKeyboardKey.arrowDown): () {
-                FocusScope.of(context).requestFocus(firstEmoticonFocusNode);
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12.0),
+            child: CallbackShortcuts(
+              bindings: {
+                LogicalKeySet(LogicalKeyboardKey.arrowDown): () {
+                  if (filteredEmoticons.isNotEmpty) {
+                    FocusScope.of(context).requestFocus(firstEmoticonFocusNode);
+                  }
+                },
               },
-            },
-            child: TextField(
-              autofocus: true,
-              focusNode: searchFocusNode,
-              decoration: const InputDecoration(
-                hintText: "Search",
-                prefixIcon: Icon(Icons.search),
+              child: TextField(
+                autofocus: true,
+                focusNode: searchFocusNode,
+                decoration: const InputDecoration(
+                  hintText: "Search",
+                  prefixIcon: Icon(Icons.search),
+                ),
+                onChanged: (value) {
+                  searchTerm.value = value;
+                },
+                onSubmitted: (value) {
+                  if (filteredEmoticons.isNotEmpty) {
+                    firstEmoticonFocusNode.requestFocus();
+                  } else {
+                    FocusScope.of(context).requestFocus(searchFocusNode);
+                  }
+                },
               ),
-              onChanged: (value) {
-                searchTerm.value = value;
-              },
-              onSubmitted: (value) {
-                searchFocusNode.nextFocus();
-              },
             ),
           ),
-          const SizedBox(height: 10),
           Expanded(
             child: GridView.builder(
               gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
@@ -165,7 +175,7 @@ class Emoticon extends HookWidget {
                   return CallbackShortcuts(
                     bindings: {
                       LogicalKeySet(LogicalKeyboardKey.escape): () {
-                        searchFocusNode.requestFocus();
+                        FocusScope.of(context).requestFocus(searchFocusNode);
                       },
                     },
                     child: Tooltip(

--- a/lib/components/root/gif.dart
+++ b/lib/components/root/gif.dart
@@ -29,7 +29,7 @@ const placeholder = SizedBox(
 );
 
 class Gif extends HookConsumerWidget {
-  const Gif({Key? key}) : super(key: key);
+  const Gif({super.key});
 
   @override
   Widget build(BuildContext context, ref) {
@@ -86,6 +86,8 @@ class Gif extends HookConsumerWidget {
     final gifs =
         text.value.isEmpty || searchGifs.isEmpty ? displayGifs : searchGifs;
 
+    FocusScope.of(context).requestFocus(searchFocusNode);
+
     useEffect(() {
       if (text.value.isNotEmpty) {
         WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -120,18 +122,28 @@ class Gif extends HookConsumerWidget {
 
     return Column(
       children: [
-        CallbackShortcuts(
-          bindings: {
-            LogicalKeySet(LogicalKeyboardKey.arrowDown): () {
-              FocusScope.of(context).requestFocus(focusNode);
+        Padding(
+          padding: const EdgeInsets.only(bottom: 12.0),
+          child: CallbackShortcuts(
+            bindings: {
+              LogicalKeySet(LogicalKeyboardKey.arrowDown): () {
+                FocusScope.of(context).requestFocus(focusNode);
+              },
             },
-          },
-          child: TextField(
-            autofocus: true,
-            focusNode: searchFocusNode,
-            onChanged: (value) => text.value = value,
-            decoration: const InputDecoration(
-              hintText: 'Search GIFs and Stickers',
+            child: TextField(
+              autofocus: true,
+              focusNode: searchFocusNode,
+              onChanged: (value) => text.value = value,
+              onSubmitted: (_) => {
+                if (gifs.isNotEmpty) {
+                  FocusScope.of(context).requestFocus(focusNode),
+                } else {
+                  FocusScope.of(context).requestFocus(searchFocusNode),
+                }
+              },
+              decoration: const InputDecoration(
+                hintText: 'Search GIFs and Stickers',
+              ),
             ),
           ),
         ),
@@ -194,8 +206,8 @@ class Gif extends HookConsumerWidget {
                         }
                       }
                     },
-                    child: Stack(
-                      children: const [
+                    child: const Stack(
+                      children: [
                         Center(
                           child: SizedBox(
                             height: 50,
@@ -221,7 +233,7 @@ class Gif extends HookConsumerWidget {
                   if (imageFile == null) {
                     return;
                   }
-                  await ClipboardWriter.instance.write([
+                  await SystemClipboard.instance?.write([
                     DataWriterItem(suggestedName: basename(gif))
                       ..add(Formats.png(imageFile))
                       ..add(Formats.bmp(imageFile))


### PR DESCRIPTION
- update the search focus for emojis, emoticons, and gifs to improve user experience and accessibility

Previously, when switching tabs with a hotkey, the focus was lost from the input element, on the desktop this led to suffering. Also, when submitting, the focus did not switch to the first found element and when pressing the down arrow key. This fix solves this problem for all tabs.